### PR TITLE
Ensuring parallel regions have balanced workflows

### DIFF
--- a/src/merfin/merfin.C
+++ b/src/merfin/merfin.C
@@ -487,12 +487,8 @@ varMers(char			       *dnaSeqName,
   
   map<string, vector<posGT*>*> *mapChrPosGT = vfile->_mapChrPosGT;
 
-  dnaSeq   seq;
-  
   uint32   pos;
   uint32   K_PADD = ksize - 1;
-
-  uint64   varMerId = 0;
   
   fprintf(stderr, "\nGenerating fasta index.\n");  
   sfile->generateIndex();
@@ -519,10 +515,11 @@ varMers(char			       *dnaSeqName,
     if ( ii + chunks > ctgn ) chunkLeft = ctgn - ii;
     fprintf(stderr, "Reading sequence %u - %u  ... \n", ii, ii+chunkLeft);
     
-#pragma omp parallel for
+#pragma omp parallel for num_threads(threads) schedule(dynamic)
     for (uint32 seqId = ii; seqId < ii + chunkLeft; seqId++) {
     //  for (uint32 seqId=0; seqId<ctgn; seqId++)  {
       dnaSeq   seq;
+      uint64   varMerId = 0;
 #pragma omp critical
       {
         sfile->findSequence(seqId);

--- a/src/merfin/merfin.C
+++ b/src/merfin/merfin.C
@@ -334,7 +334,6 @@ histKmetric(char               *outName,
   uint64   histMax  = 32 * 1024 * 1024;
   uint64 * overHist = new uint64[histMax];	// positive k* values, overHist[0] = bin 0.0 ~ 0.2
   uint64 * undrHist = new uint64[histMax];	// negative k* values
-  uint64   missing  = 0;			// missing kmers (0) 
   double   roundedReadK = 0;
   double   overcpy  = 0;
 
@@ -355,8 +354,8 @@ histKmetric(char               *outName,
   
   fprintf(stderr, "\nNumber of contigs: %u\n", ctgn);
 
-
-#pragma omp parallel for reduction (+:overcpy,tot_missing,tot_kasm) num_threads(threads) schedule(dynamic)
+   uint64 cid =0;
+#pragma omp parallel for reduction (+:overcpy) num_threads(threads) schedule(dynamic)
     for (uint32 seqId=0; seqId<ctgn;seqId++)
     {
 
@@ -416,7 +415,8 @@ histKmetric(char               *outName,
         err = 1 - pow((1-((double) missing) / kasm), (double) 1/ksize);
         qv = -10*log10(err);
 
-        fprintf(stderr, "%s\t%lu\t%lu\t%lu\t%.2f\n",
+        fprintf(stderr, "%i\t%s\t%lu\t%lu\t%lu\t%.2f\n",
+            cid++,
             seq.ident(),
             missing,
             tot_missing,
@@ -529,7 +529,7 @@ varMers(char			       *dnaSeqName,
       }
 
       //  for each seqId
-      fprintf(stderr, "Processing \'%s\' on thread  %i\n", seq.ident(),omp_get_thread_num());
+      fprintf(stderr, "Processing \'%s\'\n", seq.ident());
       
       //  get chr specific posGTs
       vector<posGT*>  *posGTlist = mapChrPosGT->at(seq.ident());

--- a/src/merfin/merfin.C
+++ b/src/merfin/merfin.C
@@ -354,7 +354,6 @@ histKmetric(char               *outName,
   
   fprintf(stderr, "\nNumber of contigs: %u\n", ctgn);
 
-   uint64 cid =0;
 #pragma omp parallel for reduction (+:overcpy) num_threads(threads) schedule(dynamic)
     for (uint32 seqId=0; seqId<ctgn;seqId++)
     {
@@ -415,8 +414,7 @@ histKmetric(char               *outName,
         err = 1 - pow((1-((double) missing) / kasm), (double) 1/ksize);
         qv = -10*log10(err);
 
-        fprintf(stderr, "%i\t%s\t%lu\t%lu\t%lu\t%.2f\n",
-            cid++,
+        fprintf(stderr, "t%s\t%lu\t%lu\t%lu\t%.2f\n",
             seq.ident(),
             missing,
             tot_missing,


### PR DESCRIPTION
I went back to figure out why the threading was generally quite unbalanced in the varMer call, and it seems to arise from the default chunking of threads.  Processing chromosomes is obviously very different from small unplaced contigs, and so the workload is poorly balanced. I ended up testing `static` -> `dynamic` and found about a 25% improvement in runtime (although some variance due to different nodes). 

Also moved the private variables into the loops to match the recent change to `seq` for consistency and clarity. The flush pragmas are also removed in favour of reduction, and is implied anyway in a critical pragma.

**NB** The order of output is lost with dynamic scheduling, but this isn't necessarily as important.